### PR TITLE
move verification, don't use wait_for because it is globally serial

### DIFF
--- a/curite/__init__.py
+++ b/curite/__init__.py
@@ -1,9 +1,22 @@
+from asyncio   import Future
 from random    import randint
-from irctokens import Line
+from re        import compile as re_compile
+from typing    import Dict
+from irctokens import build, Line
 from ircrobots import Bot as BaseBot
 from ircrobots import Server as BaseServer
+from ircrobots.formatting import strip as format_strip
 
-class Server(BaseServer):
+RE_SUCCESS = re_compile(r"^(?P<account>\S+) has not been verified.$")
+RE_ALREADY = re_compile(r"^(?P<account>\S+) is not awaiting verification.$")
+RE_INVALID = re_compile(r"^verification failed. invalid key for (?P<account>\S+).$")
+RE_ISNTREG = re_compile(r"^(?P<account>\S+) is not registered.$")
+
+class CuriteServer(BaseServer):
+    def __init__(self, bot: BaseBot, name: str):
+        super().__init__(bot, name)
+        self._waiting: Dict[str, Future[bool]] = {}
+
     async def handshake(self):
         nickname = self.params.realname
         while "#" in nickname:
@@ -14,6 +27,36 @@ class Server(BaseServer):
         self.params.username = nickname
         await super().handshake()
 
+    def verify(self, account: str, token: str):
+        account = self.casefold(account)
+        if account in self._waiting:
+            future = self._waiting[account]
+        else:
+            future = self._waiting[account] = Future()
+            self.send(build("PRIVMSG", ["NickServ", f"VERIFY REGISTER {account} {token}"]))
+        return future
+    def _verify_result(self, account: str, result: bool):
+        if (account := self.casefold(account)) in self._waiting:
+            self._waiting.pop(account).set_result(result)
+
+    async def line_read(self, line: Line):
+        if (line.command == "NOTICE" and
+                self.casefold_equals(line.hostmask.nickname, "nickserv")):
+
+            message = format_strip(line.params[1])
+
+            if (p_success := RE_SUCCESS.search(message)) is not None:
+                self._verify_result(p_success.group("account"), True)
+
+            elif (p_already := RE_ALREADY.search(message)) is not None:
+                self._verify_result(p_already.group("account"), False)
+
+            elif (p_invalid := RE_INVALID.search(message)) is not None:
+                self._verify_result(p_invalid.group("account"), False)
+
+            elif (p_isntreg := RE_ISNTREG.search(message)) is not None:
+                self._verify_result(p_isntreg.group("account"), False)
+
     def line_preread(self, line: Line):
         print(f"< {line.format()}")
     def line_presend(self, line: Line):
@@ -21,5 +64,5 @@ class Server(BaseServer):
 
 class Bot(BaseBot):
     def create_server(self, name: str):
-        return Server(self, name)
+        return CuriteServer(self, name)
 


### PR DESCRIPTION
sidestepping `wait_for` means that this will serve as many concurrent verification attempts as the asyncio httpd will handle