### PR TITLE
Autoformat files with `black`

### DIFF
--- a/curite/__init__.py
+++ b/curite/__init__.py
@@ -1,7 +1,7 @@
-from asyncio   import Future
-from random    import randint
-from re        import compile as re_compile
-from typing    import Dict
+from asyncio import Future
+from random import randint
+from re import compile as re_compile
+from typing import Dict
 from irctokens import build, Line
 from ircrobots import Bot as BaseBot
 from ircrobots import Server as BaseServer
@@ -12,6 +12,7 @@ RE_ALREADY = re_compile(r"^(?P<account>\S+) is not awaiting verification.$")
 RE_INVALID = re_compile(r"^verification failed. invalid key for (?P<account>\S+).$")
 RE_ISNTREG = re_compile(r"^(?P<account>\S+) is not registered.$")
 
+
 class CuriteServer(BaseServer):
     def __init__(self, bot: BaseBot, name: str):
         super().__init__(bot, name)
@@ -20,7 +21,7 @@ class CuriteServer(BaseServer):
     async def handshake(self):
         nickname = self.params.realname
         while "#" in nickname:
-            onerand  = str(randint(0, 9))
+            onerand = str(randint(0, 9))
             nickname = nickname.replace("#", onerand, 1)
 
         self.params.nickname = nickname
@@ -33,15 +34,19 @@ class CuriteServer(BaseServer):
             future = self._waiting[account]
         else:
             future = self._waiting[account] = Future()
-            self.send(build("PRIVMSG", ["NickServ", f"VERIFY REGISTER {account} {token}"]))
+            self.send(
+                build("PRIVMSG", ["NickServ", f"VERIFY REGISTER {account} {token}"])
+            )
         return future
+
     def _verify_result(self, account: str, result: bool):
         if (account := self.casefold(account)) in self._waiting:
             self._waiting.pop(account).set_result(result)
 
     async def line_read(self, line: Line):
-        if (line.command == "NOTICE" and
-                self.casefold_equals(line.hostmask.nickname, "nickserv")):
+        if line.command == "NOTICE" and self.casefold_equals(
+            line.hostmask.nickname, "nickserv"
+        ):
 
             message = format_strip(line.params[1])
 
@@ -59,10 +64,11 @@ class CuriteServer(BaseServer):
 
     def line_preread(self, line: Line):
         print(f"< {line.format()}")
+
     def line_presend(self, line: Line):
         print(f"> {line.format()}")
+
 
 class Bot(BaseBot):
     def create_server(self, name: str):
         return CuriteServer(self, name)
-

--- a/curite/__main__.py
+++ b/curite/__main__.py
@@ -1,10 +1,11 @@
 import asyncio
-from argparse  import ArgumentParser
+from argparse import ArgumentParser
 from ircrobots import ConnectionParams
 
-from .       import Bot
+from . import Bot
 from .config import Config, load as config_load
-from .httpd  import run as httpd_run
+from .httpd import run as httpd_run
+
 
 async def main(config: Config):
     bot = Bot()
@@ -16,18 +17,16 @@ async def main(config: Config):
         port,
         tls,
         realname=config.nickname,
-        password=config.password
+        password=config.password,
     )
     await bot.add_server(host, params)
-    await asyncio.wait([
-        httpd_run(bot, config),
-        bot.run()
-    ])
+    await asyncio.wait([httpd_run(bot, config), bot.run()])
+
 
 if __name__ == "__main__":
     parser = ArgumentParser()
     parser.add_argument("config")
-    args   = parser.parse_args()
+    args = parser.parse_args()
 
     config = config_load(args.config)
     asyncio.run(main(config))

--- a/curite/config.py
+++ b/curite/config.py
@@ -1,14 +1,15 @@
 from dataclasses import dataclass
-from re          import compile as re_compile
-from typing      import Pattern, Tuple
+from re import compile as re_compile
+from typing import Pattern, Tuple
 
 import yaml
 
+
 @dataclass
 class Config(object):
-    server:     Tuple[str, int, bool]
-    nickname:   str
-    password:   str
+    server: Tuple[str, int, bool]
+    nickname: str
+    password: str
     httpd_port: int
 
     url_success: str
@@ -16,20 +17,20 @@ class Config(object):
 
     path_pattern: Pattern
 
+
 def load(filepath: str):
     with open(filepath) as file:
         config_yaml = yaml.safe_load(file.read())
 
     nickname = config_yaml["nickname"]
-    server   = config_yaml["server"]
+    server = config_yaml["server"]
     hostname, port_s = server.split(":", 1)
-    tls      = False
+    tls = False
 
     if port_s.startswith("+"):
-        tls    = True
+        tls = True
         port_s = port_s.lstrip("+")
     port = int(port_s)
-
 
     return Config(
         (hostname, port, tls),
@@ -38,5 +39,5 @@ def load(filepath: str):
         config_yaml["httpd-port"],
         config_yaml["url-success"],
         config_yaml["url-failure"],
-        re_compile(config_yaml["path-pattern"])
+        re_compile(config_yaml["path-pattern"]),
     )

--- a/curite/httpd.py
+++ b/curite/httpd.py
@@ -1,7 +1,7 @@
 import asyncio, traceback
-from argparse     import ArgumentParser
-from asyncio      import StreamReader, StreamWriter
-from typing       import cast, List
+from argparse import ArgumentParser
+from asyncio import StreamReader, StreamWriter
+from typing import cast, List
 from urllib.parse import unquote as url_unquote
 
 from async_timeout import timeout as timeout_
@@ -11,9 +11,8 @@ from ircrobots import Bot
 from . import CuriteServer
 from .config import Config
 
-async def _headers(
-        reader: StreamReader
-        ) -> List[bytes]:
+
+async def _headers(reader: StreamReader) -> List[bytes]:
     headers: List[bytes] = []
     buffer = b""
 
@@ -22,7 +21,7 @@ async def _headers(
         if data:
             buffer += data
             headers.extend(buffer.split(b"\r\n"))
-            buffer  = headers.pop(-1)
+            buffer = headers.pop(-1)
             if b"" in headers:
                 break
         else:
@@ -30,14 +29,9 @@ async def _headers(
 
     return headers
 
-async def run(
-        bot:    Bot,
-        config: Config):
 
-    async def _client(
-            reader: StreamReader,
-            writer: StreamWriter
-            ):
+async def run(bot: Bot, config: Config):
+    async def _client(reader: StreamReader, writer: StreamWriter):
 
         try:
             async with timeout_(10):
@@ -49,7 +43,7 @@ async def run(
             print(f"! header error {str(e)}")
             return
 
-        method, path, _   = headers[0].decode("ascii").split(" ", 2)
+        method, path, _ = headers[0].decode("ascii").split(" ", 2)
         if not method == "POST":
             return
 
@@ -58,7 +52,7 @@ async def run(
             return
 
         account = url_unquote(path_match.group("account"))
-        token   = path_match.group("token")
+        token = path_match.group("token")
 
         if not bot.servers:
             return
@@ -76,10 +70,7 @@ async def run(
         else:
             url = config.url_failure
 
-        data = "\r\n".join([
-            "HTTP/1.1 302 Moved",
-            f"Location: {url}"
-        ]).encode("utf8")
+        data = "\r\n".join(["HTTP/1.1 302 Moved", f"Location: {url}"]).encode("utf8")
         # HTTP headers end with an empty line
         data += b"\r\n\r\n"
 


### PR DESCRIPTION
Autoformatting performed with `black --safe` [which ensures that the AST and thus actual behavior does not change](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#ast-before-and-after-formatting).

This should make churn in #5 far smaller