### PR TITLE
Release: Switch from buster->bullseye container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
           - x86_64-unknown-linux-gnu
     name: build
     runs-on: ubuntu-latest
-    container: rust:buster
+    container: rust:bookworm
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Hi! I wanted to deploy curite on bullseye and got:

```
curite[1067436]: /usr/local/bin/curite: error while loading shared libraries: libssl.so.1.1: cannot open shared object file: No such file or directory
```

I noticed:

```
        linux-vdso.so.1 (0x00007fffc517f000)
        libssl.so.1.1 => not found
        libcrypto.so.1.1 => not found
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f58b2453000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f58b244e000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f58b2449000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f58b2368000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f58b2363000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f58b161f000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f58b247b000)
```

I assume this is because the build happens in a Debian buster container which only contains OpenSSL 1. Buster only has OpenSSL 3. If that's the case and we don't need to support older distributions, it's probably enough to just switch the image from rust:buster to rust:bookworm.