### PR TITLE
CI: Run on PRs and merges to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
-  pull_request:
+  pull_request: {}
   push:
+    branches:
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
This is a best practice from the Vox Pupuli community. It ensures that the pipeline runs for all PRs. Because PRs can be outdated before a merge, the pipeline will run again after the merge.

Maybe you want to adopt this pattern.