### PR TITLE
CI: Build application

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,21 @@ jobs:
         with:
           command: fmt
           args: --check
+
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    container: rust:bookworm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target x86_64-unknown-linux-gnu --release --target-dir /tmp


### PR DESCRIPTION
This is a followup for https://github.com/Libera-Chat/curite/pull/14#issuecomment-1789631078

It ensures the application is not only build during the release but also for normal CI runs.