### PR TITLE
Release action: replace create with push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
 on:
-  create:
+  push:
     tags:
-      - v*
+      - 'v*'
 
 jobs:
   release:


### PR DESCRIPTION
I remember Vox Pupuli had some issues with `on: create`. I didn't find that in the docs: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions And Vox Pupuli doesn't use it anymore. This might fix our odd CI runs for the release action triggered by dependabot:
https://github.com/Libera-Chat/curite/actions/runs/9781239498