### PR TITLE
Fix verify form to actually auto-submit

### DIFF
--- a/templates/verify.html
+++ b/templates/verify.html
@@ -18,11 +18,8 @@
       <input type="submit" value="Verify">
     </form>
     <script>
-      /*
-      const form = document.getElementById('verification-form')
-
-      form.submit()
-      */
+      const form = document.getElementById('verification-form');
+      form.submit();
     </script>
 
     <p>By clicking above your Libera Chat NickServ account <code>{{account}}</code> will be verified.</p>


### PR DESCRIPTION
The page says "should be automatically redirected" if you have "JS enabled", but the page makes no attempt to do so.

Testing this locally, this works fine so uncomment this code.

If this does pose an issue, I suggest removing the text.

Follows-up b216641736dc201f8a70106c14753c68115be8a7 from 3 years ago (\cc @jesopo). I'm guessing this was temporary disabled while testing something locally but then forgotten to be re-enabled before deploying.