### PR TITLE
Fix misleading wording about auto-redirection

### DIFF
--- a/templates/verify.html
+++ b/templates/verify.html
@@ -17,16 +17,9 @@
     <form id="verification-form" method="POST"  action="{{target}}">
       <input type="submit" value="Verify">
     </form>
-    <script>
-      /*
-      const form = document.getElementById('verification-form')
-
-      form.submit()
-      */
-    </script>
+    <!--Do not have JS automatically submit the above, as some email scanners (Office 365 ATP) will run it.-->
 
     <p>By clicking above your Libera Chat NickServ account <code>{{account}}</code> will be verified.</p>
-    <p>If you have JS enabled you should be automatically redirected.</p>
   </main>
 
   <style>


### PR DESCRIPTION
We cannot verify accounts non-interactively with JS because some email scanners (e.g. Office 365 ATP) will run said JS, thus allowing accounts to be verified even if the registrant does not have access to the email's inbox.

Also fixes some unusued/missing tags.

Reported-By: @Krinkle